### PR TITLE
Setup symlink for default version download.

### DIFF
--- a/Aliases/proton
+++ b/Aliases/proton
@@ -1,0 +1,1 @@
+Formula/proton@1.3.18.rb


### PR DESCRIPTION
For future releases, e.g., proton@1.4.0:
1. Add the formula: `proton@1.4.0.rb`.
2. Update symlink for default `brew install proton`:

```bash
ln -sf ../Formula/proton@1.4.0.rb Aliases/proton
```

fix #1 